### PR TITLE
Build with Go 1.17 for native Apple M1 support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: ^1.17
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17
       -
         name: Import GPG key
         id: import_gpg

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Take a look at [test-fixtures](./hiera5/test-fixtures)
 
 ### Requirements
 
-* [Go](https://golang.org/doc/install) 1.12
+* [Go](https://golang.org/doc/install) 1.14+
 
 ### Notes
 


### PR DESCRIPTION
This change updates all GitHub workflows from Go 1.14 to Go 1.17, in particular to start building native darwin/arm64 binaries for Apple's newest machines. Terraform doesn't account for Rosetta 2 emulation when it selects providers, so without a native build of a given provider the workaround is to run a darwin/amd64 build of Terraform and use amd64 provider binaries across the board.

As far as I can tell, the current GoReleaser matrix should build for this OS + arch combination once a new enough Go version is in place.

I also updated the Go version requirement in the README to match the version from go.mod, which I'll leave at 1.14 for now.